### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,7 @@
-jupyterlab = "*"
-tensorflow-gpu = "*"
-imageio = "*"
-matplotlib = "*"
-scipy = "*"
-numpy = "*"
-skimage = "*"
+jupyterlab
+tensorflow-gpu == 1.*
+matplotlib
+scipy
+numpy
+scikit-image
 imageio == 2.4.0


### PR DESCRIPTION
remove imageio == *
skimage => scikit-image
tensorflow-gpu => tensorflow-gpu == 1.*  Because tensorflow.contrib is removed in tensorflow 2

So that it can be used via pip install -r requirements.txt