### PR TITLE
Add support for building on windows using cl

### DIFF
--- a/cuda_renderer/.gitignore
+++ b/cuda_renderer/.gitignore
@@ -1,1 +1,1 @@
-cuda_renderer
+cuda_renderer*

--- a/cuda_renderer/Makefile.mak
+++ b/cuda_renderer/Makefile.mak
@@ -1,0 +1,7 @@
+cuda_renderer: main.cu mpi_cuda.cu
+	nvcc -ccbin cl -std=c++11 -m64 -I. \
+	main.cu mpi_cuda.cu -o cuda_renderer 
+
+clean: 
+	rm cuda_renderer
+    

--- a/cuda_renderer/main.cu
+++ b/cuda_renderer/main.cu
@@ -56,7 +56,11 @@ void gpu2ffmpeg(const char* filename, uint8_t* d_out_arr_vid,
     cout << "ffmpeg, calling:" << endl;
     cout << sstm.str() << endl;
     // open a pipe to FFmpeg
-    if ( !(pPipe = popen(sstm.str().c_str(), "w")) ) {
+	#ifdef _WIN32
+	   if ( !(pPipe = _popen(sstm.str().c_str(), "w")) ) {
+	#else
+		if ( !(pPipe = popen(sstm.str().c_str(), "w")) ) {
+	#endif
         cout << "popen error" << endl;
         exit(1);
     }


### PR DESCRIPTION
Use `_popen` if on windows.

One can use `nmake -f Makefile.mak' to get a build presented by the `cl`.