### PR TITLE
fix index bounds check

### DIFF
--- a/llff/poses/pose_utils.py
+++ b/llff/poses/pose_utils.py
@@ -60,7 +60,7 @@ def save_poses(basedir, poses, pts3d, perm):
         pts_arr.append(pts3d[k].xyz)
         cams = [0] * poses.shape[-1]
         for ind in pts3d[k].image_ids:
-            if len(cams) < ind - 1:
+            if len(cams) <= ind - 1:
                 print('ERROR: the correct camera poses for current points cannot be accessed')
                 return
             cams[ind-1] = 1


### PR DESCRIPTION
if len(cams) is equal to ind-1 there will be an index error rather than printing the proper error message. This fixes this.